### PR TITLE
updated schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,7 +181,6 @@ ActiveRecord::Schema.define(:version => 20121204032057) do
     t.boolean  "comments_closed", :default => false, :null => false
     t.boolean  "sticky",          :default => false
     t.string   "last_replied_by", :default => ""
-    t.integer  "flag",            :default => 0,     :null => false
     t.datetime "last_replied_at"
   end
 


### PR DESCRIPTION
shema里，我migrate之后就显示去掉flag这个column，是你放上github前，schema没更新的原因? 

<pre>
@@ -181,7 +181,6 @@ ActiveRecord::Schema.define(:version => 20121204032057) do
     t.boolean  "comments_closed", :default => false, :null => false
     t.boolean  "sticky",          :default => false
     t.string   "last_replied_by", :default => ""
-    t.integer  "flag",            :default => 0,     :null => false
     t.datetime "last_replied_at"
   end
</pre>

