### PR TITLE
login failure message i18n

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -21,6 +21,7 @@ en:
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'
+      not_found_in_database: 'Invalid email or password.'
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'

--- a/config/locales/devise.zh.yml
+++ b/config/locales/devise.zh.yml
@@ -21,6 +21,7 @@ zh:
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'
+      not_found_in_database: '无效的用户名或密码'
       user:
         blocked: '管理员取消了您的登录权限。'
     sessions:


### PR DESCRIPTION
登录，用户不存在，消息i18n 

```
User.not found in database 
```

=> 

```
无效的用户名或密码
```
