### PR TITLE
show correct error message

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -90,8 +90,7 @@ class TopicsController < ApplicationController
   end
 
   def create_from_home
-    @node = Node.find(params[:topic][:node_id])
-    @topic = @node.topics.new(topic_params)
+    @topic = Topic.new(topic_params)
     @topic.user = current_user
 
     if @topic.save

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -197,6 +197,6 @@ class TopicsController < ApplicationController
     end
 
     def topic_params
-      params.require(:topic).permit(:title, :content)
+      params.require(:topic).permit(:title, :content, :node_id)
     end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -197,6 +197,6 @@ class TopicsController < ApplicationController
     end
 
     def topic_params
-      params.require(:topic).permit(:title, :content, :node_id)
+      params.require(:topic).permit(:title, :content, :node_id, :comments_closed, :sticky)
     end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -197,6 +197,10 @@ class TopicsController < ApplicationController
     end
 
     def topic_params
-      params.require(:topic).permit(:title, :content, :node_id, :comments_closed, :sticky)
+      if current_user.can_manage_site?
+        params.require(:topic).permit(:title, :content, :node_id, :comments_closed, :sticky)
+      else
+        params.require(:topic).permit(:title, :content, :node_id)
+      end
     end
 end

--- a/app/views/topics/new_from_home.html.slim
+++ b/app/views/topics/new_from_home.html.slim
@@ -14,4 +14,3 @@
         .checkbox
           = f.input :comments_closed, :inline_label => '禁止回复', :label => false
       = f.submit '创建新话题', :class => 'btn btn-primary btn-inverse', :data => {:disable_with => t('tips.submitting')}
-

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -40,7 +40,7 @@ RABEL_UPYUN_BUCKET_HOST: 'http://example.b0.upaiyun.com'
 # qiniu storage service
 
 # change to 'on' to turn on image upload
-RABEL_QINIU_SWITCH: 'on'
+RABEL_QINIU_SWITCH: 'off'
 
 # access key
 RABEL_QINIU_ACCESS_KEY: 'example_access_key'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -158,6 +158,11 @@ zh:
         body: "如下字段出现错误："
       full_messages:
         format: "%{attribute} %{message}"
+      models:
+        topic:
+          attributes:
+            node_id:
+              blank: "请选择正确节点"
       messages:
         inclusion: "不包含于列表中"
         exclusion: "是保留关键字"


### PR DESCRIPTION
Show correct error message if user didn't select a node when creating a topic from home.

If user wanna create a topic from home WITHOUT selecting a legal node, it will show 404:

![screen shot 2015-03-02 at 11 57 00 pm](https://cloud.githubusercontent.com/assets/1398729/6444365/1b877aa8-c138-11e4-8480-054d2b0ddad9.png)

After modifying the controller and i18n file, it will render the right page with meaningful error message:

![screen shot 2015-03-02 at 11 57 10 pm](https://cloud.githubusercontent.com/assets/1398729/6444389/404f5dce-c138-11e4-8e54-60a11a7e6513.png)


p.s. I think there should be some validations around javascript BEFORE `POST` to new_from_home if user hasn't select a node of a topic. e.g. "请先选择节点再提交". But so sorry that I don't know much about javascript and can not make it on myself. It's a BIG appreciate if someone would complete some javascript code to improve the UX in `new_from_home` page.

Thanks.